### PR TITLE
Fix wrong usage of secureSourcePassword, add $Credential to Read-CatalogEntry and fix deadlock

### DIFF
--- a/Module/MyGetPackageMigration.psm1
+++ b/Module/MyGetPackageMigration.psm1
@@ -438,7 +438,7 @@ function Read-CatalogEntry
     (
         [Parameter(Mandatory = $true)]
         $Item,
-		
+	
 	[Parameter()]
         [AllowNull()]
         [pscredential]

--- a/Module/MyGetPackageMigration.psm1
+++ b/Module/MyGetPackageMigration.psm1
@@ -439,7 +439,7 @@ function Read-CatalogEntry
         [Parameter(Mandatory = $true)]
         $Item,
 		
-		[Parameter()]
+	[Parameter()]
         [AllowNull()]
         [pscredential]
         $Credential


### PR DESCRIPTION
- $secureSourcePassword was being used instead of $SourcePassword, so password was always null
- No credentials were being used for Read-CatalogUrl in Read-CatalogEntry causing 401 Unauthorized.
- Deadlock on WaitForExit because $process.StandardOutput.ReadToEnd() was called afterwards not before as the documentation says: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?redirectedfrom=MSDN&view=netframework-4.8#System_Diagnostics_Process_StandardOutput