### PR TITLE
Update MyGetPackageMigration.psm1

### DIFF
--- a/Module/MyGetPackageMigration.psm1
+++ b/Module/MyGetPackageMigration.psm1
@@ -45,6 +45,8 @@
     .NOTES
         For more information on Personal Access Tokens - https://docs.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 #>
+
+$ErrorActionPreference = "Stop"
 function Move-MyGetNuGetPackages
 {
     [CmdletBinding()]


### PR DESCRIPTION
Add $ErrorActionPreference = "Stop", so that on error the script will stop and fully output the error message.

Currently it doesn't stop, and the error message is truncated so it's hard for users to understand what the problem is.